### PR TITLE
Smart archival mode

### DIFF
--- a/daemon/algod/api/server/v2/handlers.go
+++ b/daemon/algod/api/server/v2/handlers.go
@@ -727,7 +727,12 @@ func (v2 *Handlers) getBlockHeader(ctx echo.Context, round basics.Round, handle 
 	if err != nil {
 		switch err.(type) {
 		case ledgercore.ErrNoEntry:
-			return notFound(ctx, err, errFailedLookingUpLedger, v2.Log)
+			tmp, err := v2.fetchBlockFromS3(ctx, round)
+			if err != nil {
+				return notFound(ctx, err, errFailedLookingUpLedger, v2.Log)
+			}
+			block = tmp.BlockHeader
+			// fallback
 		default:
 			return internalError(ctx, err, errFailedLookingUpLedger, v2.Log)
 		}

--- a/daemon/algod/api/server/v2/handlers.go
+++ b/daemon/algod/api/server/v2/handlers.go
@@ -784,7 +784,9 @@ func (v2 *Handlers) fetchBlockBytesFromS3(ctx echo.Context, round basics.Round) 
 	// Build the URL
 	baseUrl, ok := os.LookupEnv("ARCHIVE_BASE_URL")
 	if !ok {
-		return nil, internalError(ctx, fmt.Errorf("archival base url not set"), "archival base url not set", v2.Log)
+		// If ARCHIVE_BASE_URL is not set, act as if the block was not found.
+		// This will guarantee non-breaking changes in the API contract when the smart archival feature is disabled.
+		return nil, notFound(ctx, errors.New("archival URL not set"), errFailedLookingUpLedger, v2.Log)
 	}
 	url := baseUrl + fmt.Sprint(round)
 

--- a/ledger/ledger.go
+++ b/ledger/ledger.go
@@ -382,29 +382,29 @@ func initBlocksDB(tx *sql.Tx, log logging.Logger, initBlocks []bookkeeping.Block
 	}
 
 	// in archival mode check if DB contains all blocks up to the latest
-	if isArchival {
-		earliest, err := blockdb.BlockEarliest(tx)
-		if err != nil {
-			err = fmt.Errorf("initBlocksDB.blockEarliest %v", err)
-			return err
-		}
+	//if isArchival {
+	//	earliest, err := blockdb.BlockEarliest(tx)
+	//	if err != nil {
+	//		err = fmt.Errorf("initBlocksDB.blockEarliest %v", err)
+	//		return err
+	//	}
 
-		// Detect possible problem - archival node needs all block but have only subsequence of them
-		// So reset the DB and init it again
-		if earliest != basics.Round(0) {
-			log.Warnf("resetting blocks DB (earliest block is %v)", earliest)
-			err := blockdb.BlockResetDB(tx)
-			if err != nil {
-				err = fmt.Errorf("initBlocksDB.blockResetDB %v", err)
-				return err
-			}
-			err = blockdb.BlockInit(tx, initBlocks)
-			if err != nil {
-				err = fmt.Errorf("initBlocksDB.blockInit 2 %v", err)
-				return err
-			}
-		}
-	}
+	//	// Detect possible problem - archival node needs all block but have only subsequence of them
+	//	// So reset the DB and init it again
+	//	if earliest != basics.Round(0) {
+	//		log.Warnf("resetting blocks DB (earliest block is %v)", earliest)
+	//		err := blockdb.BlockResetDB(tx)
+	//		if err != nil {
+	//			err = fmt.Errorf("initBlocksDB.blockResetDB %v", err)
+	//			return err
+	//		}
+	//		err = blockdb.BlockInit(tx, initBlocks)
+	//		if err != nil {
+	//			err = fmt.Errorf("initBlocksDB.blockInit 2 %v", err)
+	//			return err
+	//		}
+	//	}
+	//}
 
 	return nil
 }


### PR DESCRIPTION
# Summary

This pull request implements the smart archival feature (for lack of a better name), which changes the way normal archival mode works:
* When switching from a light node to an archival node, the ledger will not fetch all blocks starting from block 0. Instead, it will keep behaving like a light node.
* When a block is requested to the Algod API and the block is not in the ledger, Algod will fetch the block from a configurable repository.

Note that the observable behavior from `GET /v2/blocks/{round}` does not change, there are no breaking changes in the interface / contract (except maybe increased latency for archived blocks).

